### PR TITLE
Stop spinning on script startup

### DIFF
--- a/Controllers/ThreadController.py
+++ b/Controllers/ThreadController.py
@@ -39,7 +39,7 @@ class Program:
         HorizontalOutput = self.clamp((leash.X_Positive - leash.X_Negative) * leash.Stretch * leash.settings.StrengthMultiplier)
 
         #Turning Math
-        if leash.settings.TurningEnabled and leash.Stretch > leash.settings.TurningDeadzone:
+        if leash.settings.TurningEnabled and leash.Stretch > leash.settings.TurningDeadzone and leash.Grabbed:
             TurnDirect = None
             match leash.LeashDirection:
                 case "North":
@@ -114,7 +114,7 @@ class Program:
             print("Waiting...")
 
             leash.Active = False
-            self.leashOutput(0.0, 0.0, 0, 0, leash.settings)
+            self.leashOutput(0.0, 0.0, 0.0, 0, leash.settings)
             self.resetProgram()
 
             time.sleep(leash.settings.InactiveDelay)


### PR DESCRIPTION
When launching the script with VRChat open, it would start spinning me until a leash was grabbed and released. This fixes that.