### PR TITLE
Add OSCQuery support (for parameter receiving from VRChat)

### DIFF
--- a/Config.json
+++ b/Config.json
@@ -15,6 +15,7 @@
         "InactiveDelay": 0.5,
         "Logging": false,
         "XboxJoystickMovement": false,
+        "UseOSCQuery": true,
         
         "PhysboneParameters":
         [

--- a/Config.json
+++ b/Config.json
@@ -15,7 +15,7 @@
         "InactiveDelay": 0.5,
         "Logging": false,
         "XboxJoystickMovement": false,
-        "UseOSCQuery": true,
+        "UseOSCQuery": false,
         
         "PhysboneParameters":
         [

--- a/Controllers/DataController.py
+++ b/Controllers/DataController.py
@@ -19,7 +19,7 @@ DefaultConfig = {
         "InactiveDelay": 0.5,
         "Logging": False,
         "XboxJoystickMovement": False,
-        "UseOSCQuery": True,
+        "UseOSCQuery": False,
         
         "PhysboneParameters":
         [

--- a/Controllers/DataController.py
+++ b/Controllers/DataController.py
@@ -19,6 +19,7 @@ DefaultConfig = {
         "InactiveDelay": 0.5,
         "Logging": False,
         "XboxJoystickMovement": False,
+        "UseOSCQuery": True,
         
         "PhysboneParameters":
         [
@@ -61,6 +62,7 @@ class ConfigSettings:
             self.Logging = configJson["Logging"]
             self.XboxJoystickMovement = configJson["XboxJoystickMovement"]
             self.Leashes = configJson["PhysboneParameters"]
+            self.UseOSCQuery = configJson["UseOSCQuery"]
         except Exception as e: 
             print('\x1b[1;31;40m' + 'Malformed Config.json contents. Was something missing?' + '\x1b[0m')
             print(f"Exception: {e}\nDefault Config will be loaded.\n")
@@ -84,6 +86,7 @@ class ConfigSettings:
             self.Logging = DefaultConfig["Logging"]
             self.XboxJoystickMovement = DefaultConfig["XboxJoystickMovement"]
             self.Leashes = DefaultConfig["PhysboneParameters"]
+            self.UseOSCQuery = DefaultConfig["UseOSCQuery"]
 
     def addGamepadControls(self, gamepad, runButton):
         self.gamepad = gamepad

--- a/OSCLeash.py
+++ b/OSCLeash.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     try:
         # Manage data coming in
         if len(leashes) == 0: raise Exception("No leashes found. Please update config file.")
-        package = Package(leashes)
+        package = Package(leashes, configData['UseOSCQuery'])
         package.listen()
 
         # Start server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python_osc>=1.8.0
 vgamepad>=0.0.8
+https://github.com/cyberkitsune/tinyoscquery/archive/refs/tags/0.1.2.zip


### PR DESCRIPTION
Hey!

This pull request uses `tinyoscquery` to add basic support for OSCQuery. It will advertise all the endpoints OSCLeash expects to receive, and VRChat will send OSCLeash the parameters regardless of the port it is running on.

In OSCQuery mode, the OSC server port is also randomized to any non-occupied UDP port on the system.

Tested and works for me ™️ 