### PR TITLE
Bump tinyoscquery to version 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python_osc>=1.8.0
 vgamepad>=0.0.8
-https://github.com/cyberkitsune/tinyoscquery/archive/refs/tags/0.1.2.zip
+https://github.com/cyberkitsune/tinyoscquery/archive/refs/tags/0.1.3.zip


### PR DESCRIPTION
This should fix the pyinstaller import issues with python-zeroconf.