### PR TITLE
Linux QoL changes

### DIFF
--- a/Controllers/DataController.py
+++ b/Controllers/DataController.py
@@ -66,7 +66,7 @@ class ConfigSettings:
         except Exception as e: 
             print('\x1b[1;31;40m' + 'Malformed Config.json contents. Was something missing?' + '\x1b[0m')
             print(f"Exception: {e}\nDefault Config will be loaded.\n")
-            os.system("pause")
+            program.pause()
             print("")
 
             self.IP = DefaultConfig["IP"]

--- a/Controllers/ThreadController.py
+++ b/Controllers/ThreadController.py
@@ -199,6 +199,9 @@ class Program:
         """Clears Console"""
         os.system('cls' if os.name == 'nt' else 'clear')
 
+    def pause(self): #
+        os.system('pause' if os.name == 'nt' else 'read -n1 -r -p "Press any key to continue..."')
+
     def setWindowTitle(self): # Set window title
         if os.name == 'nt':
             ctypes.windll.kernel32.SetConsoleTitleW("OSCLeash")

--- a/OSCLeash.py
+++ b/OSCLeash.py
@@ -1,6 +1,7 @@
+#!/usr/bin/env python3
 from threading import Thread
 import json
-import sys
+from sys import platform
 import os
 import time
 
@@ -27,7 +28,7 @@ def createDefaultConfigFile(configPath): # Creates a default config
 
     except Exception as e:
         print(e)
-        os.system("pause")
+        program.pause()
         exit()
 
 
@@ -41,14 +42,22 @@ if __name__ == "__main__":
     
     print('\x1b[1;32;40m' + f"OSCLeash {__version__}" + '\x1b[0m')
 
+    # Choose configuration path based on operating system if no override is set
+    configPathOverride = os.environ.get('OSCLEASH_CONFIG_PATH')
+    if configPathOverride is not None:
+        configPath = configPathOverride
+    elif platform == 'win32':
+        configPath = f"{os.environ.get('LocalAppData')}\Programs\OSCLeash\Config.json"
+    elif platform == 'linux': 
+        configPath = f"{os.environ.get('XDG_CONFIG_HOME', f"{os.environ.get('HOME')}/.config/")}/OSCLeash/Config.json"
+
     # Test if Config file exists. Create the default if it does not.
-    configPath: str = os.environ.get("OSCLEASH_CONFIG_PATH", f"{os.getcwd()}/Config.json")
-    if not os.path.exists(configPath):
+    if not os.path.isfile(configPath):
         # print error message in red
         print('\x1b[1;31;40m' + "Config file was not found...", "\nCreating default config file..." + '\x1b[0m')
         createDefaultConfigFile(configPath)
     else:
-        print("Config file found\n")
+        print(f"Config file found at {configPath}\n")
 
     # load settings
     try:
@@ -58,7 +67,7 @@ if __name__ == "__main__":
         print(f"{e}\nDefault Config will be loaded.\n")
 
         configData = DefaultConfig
-        os.system("pause")
+        program.pause()
         
     settings = ConfigSettings(configData)
 
@@ -72,7 +81,7 @@ if __name__ == "__main__":
         except Exception as e:
             print('\x1b[1;31;40m' + f'Error: {e}\nWarning: Switching to default OSC settings. Please wait...\n Check documentation for controller emulator tool.' + '\x1b[0m')
             settings.XboxJoystickMovement = False
-            os.system("pause")
+            program.pause()
 
     # Collect Data for leash
     leashes = []
@@ -99,5 +108,5 @@ if __name__ == "__main__":
             
     except Exception as e:
         print(e)
-        os.system("pause")
+        program.pause()
         os.execl(sys.executable, sys.executable, *sys.argv)

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ If all else fails, feel free to reach out in the #OSC-Talkin channel in [my Disc
 
 
 # Config
-After running OSCleash at least once, an OSCLeash.json file will be generated. <br>
-The default install location of OSCLeash is `%LocalAppData%\Programs\OSCLeash` <br>
-You can open the json file in your favorite text editor and fine tune your OSCLeash.
+After running OSCleash at least once, a `Config.json` file will be generated.  
+  
+This configuration file will be located at `%LocalAppData%\Programs\OSCLeash\Config.json` (Windows), `$XDG_CONFIG_HOME/OSCLeash/Config.json` (Linux), or `$HOME/.config/OSCLeash/Config.json` (Linux, fallback). The `OSCLEASH_CONFIG_PATH` environment variable can be used to override the default config location. 
+   
+You can open the `Config.json` file in your favorite text editor to fine tune your OSCLeash. 
 
 <details><summary>Table of Configation settings</summary>
 


### PR DESCRIPTION
General quality of life changes for Linux (and incidentally also a couple that apply other OSes):
- Use sensible default paths for `Config.json` based on operating system
- Explain default config paths in the README
- Use `#!/usr/bin/env python` shebang for simpler execution on Linux
- Use UNIX line endings in `OSCLeash.py` for better Linux compat when taking advantage of the aforementioned shebang
- Fix uses of `pause` on Linux
- Check that `configPath` is actually a file or symlink

I do not have a Windows system to test these changes on. While nothing I changed should cause any regressions on Windows, please test anyway and let me know if everything is functional. 

If merged I believe this warrants a version bump to benefit users of stable packages like Arch's [`aur/oscleash`](https://aur.archlinux.org/packages/oscleash). 